### PR TITLE
refactor external channel handler to use  headers config on send

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -52,6 +52,9 @@ const (
 
 	// ConfigUseNational is a constant key for channel configs
 	ConfigUseNational = "use_national"
+
+	// ConfigSendHeaders is a constant key for channel configs
+	ConfigSendHeaders = "headers"
 )
 
 // ChannelType is our typing of the two char channel types

--- a/handlers/external/external.go
+++ b/handlers/external/external.go
@@ -353,9 +353,12 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 		}
 		req.Header.Set("Content-Type", contentTypeHeader)
 
-		authorization := msg.Channel().StringConfigForKey(courier.ConfigSendAuthorization, "")
-		if authorization != "" {
-			req.Header.Set("Authorization", authorization)
+		headers := msg.Channel().ConfigForKey(courier.ConfigSendHeaders, map[string]interface{}{}).(map[string]interface{})
+
+		if len(headers) > 0 {
+			for hKey, hValue := range headers {
+				req.Header.Set(hKey, fmt.Sprint(hValue))
+			}
 		}
 
 		rr, err := utils.MakeHTTPRequest(req)

--- a/handlers/external/external_test.go
+++ b/handlers/external/external_test.go
@@ -423,11 +423,11 @@ func TestSending(t *testing.T) {
 
 	var jsonChannel = courier.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "US",
 		map[string]interface{}{
-			"send_path":                     "",
-			courier.ConfigSendBody:          `{ "to":{{to}}, "text":{{text}}, "from":{{from}}, "quick_replies":{{quick_replies}} }`,
-			courier.ConfigContentType:       contentJSON,
-			courier.ConfigSendMethod:        http.MethodPost,
-			courier.ConfigSendAuthorization: "Token ABCDEF",
+			"send_path":               "",
+			courier.ConfigSendBody:    `{ "to":{{to}}, "text":{{text}}, "from":{{from}}, "quick_replies":{{quick_replies}} }`,
+			courier.ConfigContentType: contentJSON,
+			courier.ConfigSendMethod:  http.MethodPost,
+			courier.ConfigSendHeaders: map[string]interface{}{"Authorization": "Token ABCDEF", "foo": "bar"},
 		})
 
 	var xmlChannel = courier.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "US",
@@ -472,22 +472,22 @@ func TestSending(t *testing.T) {
 
 	var jsonChannel30IntLength = courier.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "US",
 		map[string]interface{}{
-			"send_path":                     "",
-			"max_length":                    30,
-			courier.ConfigSendBody:          `{ "to":{{to}}, "text":{{text}}, "from":{{from}}, "quick_replies":{{quick_replies}} }`,
-			courier.ConfigContentType:       contentJSON,
-			courier.ConfigSendMethod:        http.MethodPost,
-			courier.ConfigSendAuthorization: "Token ABCDEF",
+			"send_path":               "",
+			"max_length":              30,
+			courier.ConfigSendBody:    `{ "to":{{to}}, "text":{{text}}, "from":{{from}}, "quick_replies":{{quick_replies}} }`,
+			courier.ConfigContentType: contentJSON,
+			courier.ConfigSendMethod:  http.MethodPost,
+			courier.ConfigSendHeaders: map[string]interface{}{"Authorization": "Token ABCDEF", "foo": "bar"},
 		})
 
 	var xmlChannel30IntLength = courier.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "US",
 		map[string]interface{}{
-			"send_path":                     "",
-			"max_length":                    30,
-			courier.ConfigSendBody:          `<msg><to>{{to}}</to><text>{{text}}</text><from>{{from}}</from><quick_replies>{{quick_replies}}</quick_replies></msg>`,
-			courier.ConfigContentType:       contentXML,
-			courier.ConfigSendMethod:        http.MethodPost,
-			courier.ConfigSendAuthorization: "Token ABCDEF",
+			"send_path":               "",
+			"max_length":              30,
+			courier.ConfigSendBody:    `<msg><to>{{to}}</to><text>{{text}}</text><from>{{from}}</from><quick_replies>{{quick_replies}}</quick_replies></msg>`,
+			courier.ConfigContentType: contentXML,
+			courier.ConfigSendMethod:  http.MethodPost,
+			courier.ConfigSendHeaders: map[string]interface{}{"Authorization": "Token ABCDEF", "foo": "bar"},
 		})
 
 	RunChannelSendTestCases(t, getChannel30IntLength, newHandler(), longSendTestCases, nil)


### PR DESCRIPTION
related to https://github.com/nyaruka/courier/pull/386