### PR TITLE
Feature/facebook customer feedback

### DIFF
--- a/handlers/facebookapp/facebookapp_test.go
+++ b/handlers/facebookapp/facebookapp_test.go
@@ -415,6 +415,41 @@ var unkownMessagingEntry = `{
 	}]
 }`
 
+var customerFeedbackResponse = `{
+  "object": "page",
+  "entry": [
+    {
+      "id": "1234",
+			"time": 1459991487970,
+      "messaging": [
+        {
+          "recipient": {
+            "id": "1234"
+          },
+          "timestamp": 1459991487970,
+          "sender": {
+            "id": "5678"
+          },
+          "messaging_feedback": {
+            "feedback_screens": [
+              {
+                "screen_id": 0,
+                "questions": {
+                  "test_question": {
+                    "type": "CSAT",
+                    "payload": "4"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}
+`
+
 var notJSON = `blargh`
 
 var testCases = []ChannelHandleTestCase{
@@ -477,6 +512,10 @@ var testCases = []ChannelHandleTestCase{
 	{Label: "Unknown Messaging Entry", URL: "/c/fba/receive", Data: unkownMessagingEntry, Status: 200, Response: "Handled", PrepRequest: addValidSignature},
 	{Label: "Not JSON", URL: "/c/fba/receive", Data: notJSON, Status: 400, Response: "Error", PrepRequest: addValidSignature},
 	{Label: "Invalid URN", URL: "/c/fba/receive", Data: invalidURN, Status: 400, Response: "invalid facebook id", PrepRequest: addValidSignature},
+
+	{Label: "Receive Customer Feedback Message", URL: "/c/fba/receive", Data: customerFeedbackResponse, Status: 200, Response: "Handled", NoQueueErrorCheck: true, NoInvalidChannelCheck: true,
+		Text: Sp("4"), URN: Sp("facebook:5678"), Date: Tp(time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC)),
+		PrepRequest: addValidSignature},
 }
 
 func addValidSignature(r *http.Request) {


### PR DESCRIPTION

support to receive messaging_feedback webhook event on facebookapp handler, from response of a customer feedback template.

with this, rapidpro can receive the result as question payload from customer answer.

reference: https://developers.facebook.com/docs/messenger-platform/send-messages/templates/customer-feedback-template/

add support to send customer feedback template from send message with a specifc protocol.
```
{customer_feedback_template}|
title: Avalie sua experiência conosco|
subtitle:nos ajude a melhorar a eficiência do serviço|
button_title:Avaliar|
question_title:Como foi sua experiência na conversa?|
question_id:definida_pelo_usuario|
type:csat|
score_label:neg_pos|
score_option:five_stars|
business_privacy:www.example.com|
follow_up:true|
follow_up_placeholder: feedback adicional...
```