### PR TITLE
add handling for whatsapp 9 extra number for facebookapp

### DIFF
--- a/handlers/facebookapp/facebookapp.go
+++ b/handlers/facebookapp/facebookapp.go
@@ -1204,11 +1204,18 @@ type wacMTResponse struct {
 	Messages []*struct {
 		ID string `json:"id"`
 	} `json:"messages"`
+	Contacts []*struct {
+		Input string `json:"input,omitempty"`
+		WaID  string `json:"wa_id,omitempty"`
+	} `json:"contacts,omitempty"`
 }
 
 func (h *handler) sendCloudAPIWhatsappMsg(ctx context.Context, msg courier.Msg) (courier.MsgStatus, error) {
 	// can't do anything without an access token
 	accessToken := h.Server().Config().WhatsappAdminSystemUserToken
+
+	start := time.Now()
+	hasNewURN := false
 
 	base, _ := url.Parse(graphURL)
 	path, _ := url.Parse(fmt.Sprintf("/%s/messages", msg.Channel().Address()))
@@ -1426,6 +1433,22 @@ func (h *handler) sendCloudAPIWhatsappMsg(ctx context.Context, msg courier.Msg) 
 		}
 		// this was wired successfully
 		status.SetStatus(courier.MsgWired)
+
+		// if payload.contacts[0].wa_id != payload.contacts[0].input | to fix cases with 9 extra
+		if len(respPayload.Contacts) > 0 && respPayload.Contacts[0].WaID != msg.URN().Path() {
+			if !hasNewURN {
+				toUpdateURN, err := urns.NewWhatsAppURN(respPayload.Contacts[0].WaID)
+				if err != nil {
+					return status, nil
+				}
+				err = status.SetUpdatedURN(msg.URN(), toUpdateURN)
+				if err != nil {
+					log := courier.NewChannelLogFromError("unable to update contact URN for a new based on  wa_id", msg.Channel(), msg.ID(), time.Since(start), err)
+					status.AddLog(log)
+				}
+				hasNewURN = true
+			}
+		}
 
 	}
 	return status, nil

--- a/handlers/facebookapp/facebookapp_test.go
+++ b/handlers/facebookapp/facebookapp_test.go
@@ -701,6 +701,13 @@ var SendTestCasesWAC = []ChannelSendTestCase{
 			},
 		},
 		SendPrep: setSendURL},
+	{Label: "Update URN with wa_id returned",
+		Text: "Simple Message", URN: "whatsapp:5511987654321", Path: "/12345_ID/messages",
+		Status: "W", ExternalID: "157b5e14568e8",
+		ResponseBody: `{ "contacts":[{"input":"5511987654321", "wa_id":"551187654321"}], "messages": [{"id": "157b5e14568e8"}] }`, ResponseStatus: 201,
+		RequestBody: `{"messaging_product":"whatsapp","preview_url":false,"recipient_type":"individual","to":"5511987654321","type":"text","text":{"body":"Simple Message"}}`,
+		SendPrep:    setSendURL,
+		NewURN:      "whatsapp:551187654321"},
 }
 
 func TestSending(t *testing.T) {


### PR DESCRIPTION
on send message, compare wa_id returned in payload of request to send message, with URN path provided by msg event and update URN with that wa_id if is different of number in path.